### PR TITLE
Make `std::sync` usage optional.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         toolchain: [stable, 1.63.0, beta, nightly]
+        features: ['', 'sync']
 
     runs-on: ubuntu-latest
     continue-on-error: "${{ matrix.toolchain != 'nightly' && matrix.toolchain != 'beta' }}"
@@ -45,24 +46,24 @@ jobs:
 
     - name: Compile
       # compile is broken out so we have visibility into compile vs. run times
-      run: cargo test --all-features --timings --no-run
+      run: cargo test --no-default-features --features="${{ matrix.features }}" --timings --no-run
 
     - name: Run tests
-      run: cargo test --all-features
+      run: cargo test --no-default-features --features="${{ matrix.features }}" --timings
 
     - name: Compile on Wasm
       # We don't yet have tests that can run on Wasm, but this will check for compile success.
       # Examples can't all build on Wasm, so no --all-targets.
-      run: cargo build --target wasm32-unknown-unknown
+      run: cargo build --no-default-features --features="${{ matrix.features }}" --target wasm32-unknown-unknown
 
     - name: Update
       run: cargo update
 
     - name: Compile with updates
-      run: cargo test --timings --no-run
+      run: cargo test --no-default-features --features="${{ matrix.features }}" --timings --no-run
 
     - name: Test with updates
-      run: cargo test --timings
+      run: cargo test --no-default-features --features="${{ matrix.features }}" --timings
 
     # Save timing reports so we can download and view them
     # (for understanding build performance in CI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `basic_yield_now()` is a yield function that may be adequate rather than writing your own.
 * `Builder` is a builder for `YieldProgress` instances.
 * `ProgressInfo` and `YieldInfo` offer information to the callback functions.
+* Feature `sync` may be disabled to avoid requiring `std::sync`.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,17 @@ keywords = ["yield", "progressbar"]
 publish = true
 exclude = [".github", ".vscode"]
 
+[features]
+default = ["sync"]
+# Implements `YieldProgress: Send + Sync` for use with multi-threaded executors.
+# Requires `std` to be available for the compilation target.
+sync = []
+
+[[example]]
+name = "interactive-cancel"
+required-features = ["sync"]
+test = false
+
 [dependencies]
 # Used for logging over-long intervals between yields. TODO: This should be pluggable and optional
 log = { version = "0.4.17", default-features = false }

--- a/src/maybe_sync.rs
+++ b/src/maybe_sync.rs
@@ -24,19 +24,17 @@ mod not_sync {
     pub(crate) use core::cell::RefCell as StateCell;
 
     /// For internal convenience, make `RefCell` look like `Mutex`.
+    ///
     /// This trait is only used as an extension trait for the method, not generically.
+    /// That is less code and lets us avoid use of a generic associated type, which is required
+    /// for our MSRV of 1.63 < 1.65.
     pub(crate) trait Mutexish {
-        type WriteGuard<'a>
-        where
-            Self: 'a;
-        type Error;
-        fn lock(&self) -> Result<Self::WriteGuard<'_>, Self::Error>;
+        type Target;
+        fn lock(&self) -> Result<std::cell::RefMut<'_, Self::Target>, std::cell::BorrowMutError>;
     }
     impl<T> Mutexish for std::cell::RefCell<T> {
-        type WriteGuard<'a> = std::cell::RefMut<'a, T> where T: 'a;
-        type Error = std::cell::BorrowMutError;
-
-        fn lock(&self) -> Result<Self::WriteGuard<'_>, Self::Error> {
+        type Target = T;
+        fn lock(&self) -> Result<std::cell::RefMut<'_, T>, std::cell::BorrowMutError> {
             self.try_borrow_mut()
         }
     }

--- a/src/maybe_sync.rs
+++ b/src/maybe_sync.rs
@@ -1,0 +1,48 @@
+//! Shims to help with being conditionally [`Sync`].
+
+#[cfg(not(feature = "sync"))]
+pub(crate) use not_sync::*;
+#[cfg(feature = "sync")]
+pub(crate) use sync::*;
+
+#[cfg(feature = "sync")]
+mod sync {
+    pub(crate) use std::sync::Arc as MaRc;
+    pub(crate) use std::sync::Mutex as StateCell;
+
+    pub(crate) trait Mutexish {}
+
+    macro_rules! maybe_send_impl_future {
+        ($t:ty) => { impl Future<Output = $t> + Send + 'static }
+    }
+    pub(crate) use maybe_send_impl_future;
+}
+
+#[cfg(not(feature = "sync"))]
+mod not_sync {
+    pub(crate) use alloc::rc::Rc as MaRc;
+    pub(crate) use core::cell::RefCell as StateCell;
+
+    /// For internal convenience, make `RefCell` look like `Mutex`.
+    /// This trait is only used as an extension trait for the method, not generically.
+    pub(crate) trait Mutexish {
+        type WriteGuard<'a>
+        where
+            Self: 'a;
+        type Error;
+        fn lock(&self) -> Result<Self::WriteGuard<'_>, Self::Error>;
+    }
+    impl<T> Mutexish for std::cell::RefCell<T> {
+        type WriteGuard<'a> = std::cell::RefMut<'a, T> where T: 'a;
+        type Error = std::cell::BorrowMutError;
+
+        fn lock(&self) -> Result<Self::WriteGuard<'_>, Self::Error> {
+            self.try_borrow_mut()
+        }
+    }
+
+    macro_rules! maybe_send_impl_future {
+        ($t:ty) => { impl Future<Output = $t> + 'static }
+    }
+    pub(crate) use maybe_send_impl_future;
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc::{self, error::TryRecvError};
 
 use crate::{Builder, YieldProgress};
 
+#[cfg(feature = "sync")]
 fn assert_send_sync<T: Send + Sync>() {
     // We don't need to do anything in this function; the call to it having been successfully
     // compiled is the assertion.
@@ -58,6 +59,7 @@ impl YpLog {
 }
 
 #[test]
+#[cfg(feature = "sync")]
 fn yield_progress_is_sync() {
     assert_send_sync::<YieldProgress>()
 }


### PR DESCRIPTION
Part of #2.