### PR TITLE
Add `split_concurrent()` for reporting concurrent tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Added `YieldProgress::split_concurrent()` for reporting progress from concurrent tasks.
+
 ## 0.1.5 (2023-12-25)
 
 * `YieldProgress::noop()` is no longer deprecated.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,7 +15,8 @@ use crate::{
 #[must_use]
 pub struct Builder {
     yielding: MaRc<Yielding<crate::YieldFn>>,
-    progressor: MaRc<crate::ProgressFn>,
+    /// public to allow overriding the API `Sync` requirement
+    pub(crate) progressor: MaRc<crate::ProgressFn>,
 }
 
 impl Builder {
@@ -78,6 +79,12 @@ impl Builder {
             },
             state: StateCell::new(self.yielding.state.lock().unwrap().clone()),
         });
+        self.yielding = new_yielding;
+        self
+    }
+
+    /// Internal version of `yield_using` which takes an already boxed function and yielding state.
+    pub(crate) fn yielding_internal(mut self, new_yielding: crate::BoxYielding) -> Self {
         self.yielding = new_yielding;
         self
     }

--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -1,0 +1,64 @@
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "sync"))]
+use crate::Mutexish as _;
+use crate::{MaRc, ProgressInfo, StateCell, YieldProgress};
+
+/// Aggregate progress information from multiple concurrent tasks.
+pub(crate) struct ConcurrentProgress {
+    parent: YieldProgress,
+    children: StateCell<Vec<Child>>,
+}
+
+#[derive(Default)]
+struct Child {
+    fraction: f32,
+    label: Option<MaRc<str>>,
+}
+
+impl ConcurrentProgress {
+    pub(crate) fn new(parent: YieldProgress, count: usize) -> MaRc<Self> {
+        MaRc::new(Self {
+            parent,
+            children: StateCell::new(
+                core::iter::repeat_with(Default::default)
+                    .take(count)
+                    .collect(),
+            ),
+        })
+    }
+
+    pub(crate) fn progressor(self: MaRc<Self>, index: usize) -> impl Fn(&ProgressInfo<'_>) {
+        move |info| {
+            let &ProgressInfo {
+                fraction,
+                label,
+                location,
+            } = info;
+
+            let children = &mut self.children.lock().unwrap();
+
+            // Store new state.
+            let child_state = &mut children[index];
+            child_state.fraction = fraction;
+            child_state.label = label.cloned();
+
+            // Compute combined results.
+            let sum: f32 = children
+                .iter()
+                .map(|child_state| child_state.fraction)
+                .sum();
+            let fraction = sum / (children.len() as f32);
+
+            let first_incomplete_label = children
+                .iter()
+                .filter(|child_state| child_state.fraction < 1.0)
+                .filter_map(|child_state| child_state.label.as_ref())
+                .next();
+
+            // Deliver combined results.
+            self.parent
+                .send_progress(fraction, first_incomplete_label, location);
+        }
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -3,7 +3,7 @@ use core::panic::Location;
 /// Information available to a progress callback.
 pub struct ProgressInfo<'a> {
     pub(crate) fraction: f32,
-    pub(crate) label: &'a str,
+    pub(crate) label: Option<&'a crate::MaRc<str>>,
     pub(crate) location: &'a Location<'a>,
 }
 impl<'a> ProgressInfo<'a> {
@@ -19,7 +19,7 @@ impl<'a> ProgressInfo<'a> {
     pub fn label_str(&self) -> &str {
         // This function is called `label_str()`, and does not return`&'a str`, to leave room for a
         // non-string label being offered as a non-breaking change.
-        self.label
+        self.label.map_or("", |label_rc| &**label_rc)
     }
 
     /// Source code location which reported the progress.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,7 @@ impl YieldProgress {
     /// subranges.
     ///
     /// The returned instances should be used in sequence, but this is not enforced.
+    /// Using them concurrently will result in the progress bar jumping backwards.
     pub fn split(self, cut: f32) -> [Self; 2] {
         let cut_abs = self.point_in_range(cut);
         [
@@ -336,6 +337,9 @@ impl YieldProgress {
     }
 
     /// Split into even subdivisions.
+    ///
+    /// The returned instances should be used in sequence, but this is not enforced.
+    /// Using them concurrently will result in the progress bar jumping backwards.
     pub fn split_evenly(
         self,
         count: usize,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -189,4 +189,33 @@ async fn split_evenly_with_max() {
     assert_eq!(r.drain(), vec![Progress(1.0, "".into()), Yielded, Dropped]);
 }
 
+#[tokio::test]
+async fn split_concurrent() {
+    let (p, mut r) = logging_yield_progress();
+    let mut iter = p.split_concurrent(2);
+    let mut p1 = iter.next().unwrap();
+    let mut p2 = iter.next().unwrap();
+    p1.set_label("p1");
+    p2.set_label("p2");
+    p1.progress(0.5).await;
+    p2.progress(0.5).await;
+    p1.finish().await;
+    p2.finish().await;
+    // TODO: we should have a better rule for combining labels.
+    // This test is looking for "first nonempty nonfinished label".
+    assert_eq!(
+        r.drain(),
+        vec![
+            Progress(0.25, "p1".into()),
+            Yielded,
+            Progress(0.5, "p1".into()),
+            Yielded,
+            Progress(0.75, "p2".into()),
+            Yielded,
+            Progress(1.0, "".into()),
+            Yielded,
+        ]
+    );
+}
+
 // TODO: test split()


### PR DESCRIPTION
Implements #20.