### PR TITLE
CI: Split cache by toolchain.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
 
     # Load cache before doing any Rust builds
     - uses: Swatinem/rust-cache@v2.0.2
+      with:
+        # Split by toolchain to avoid collisions.
+        # We'll still collide on features, but that should be mostly okay and save some disk.
+        prefix-key: "v1-rust-${{ matrix.toolchain }}"
 
     - name: Lint
       run: |


### PR DESCRIPTION
I noticed the rust-cache action reporting collisions.
This won't remove all of them but should remove enough of them to improve CI performance on the 1.63 toolchain.