### PR TITLE
Rename `split_concurrent()` to `split_evenly_concurrent()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added `YieldProgress::split_concurrent()` for reporting progress from concurrent tasks.
+* Added `YieldProgress::split_evenly_concurrent()` for reporting progress from concurrent tasks.
 
 ## 0.1.5 (2023-12-25)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl YieldProgress {
     /// The label passed through will be the label from the first subtask that has a progress
     /// value less than 1.0. This choice may be changed in the future if the label system is
     /// elaborated.
-    pub fn split_concurrent(
+    pub fn split_evenly_concurrent(
         self,
         count: usize,
     ) -> impl DoubleEndedIterator<Item = YieldProgress> + ExactSizeIterator + FusedIterator {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -190,9 +190,9 @@ async fn split_evenly_with_max() {
 }
 
 #[tokio::test]
-async fn split_concurrent() {
+async fn split_evenly_concurrent() {
     let (p, mut r) = logging_yield_progress();
-    let mut iter = p.split_concurrent(2);
+    let mut iter = p.split_evenly_concurrent(2);
     let mut p1 = iter.next().unwrap();
     let mut p2 = iter.next().unwrap();
     p1.set_label("p1");
@@ -201,7 +201,8 @@ async fn split_concurrent() {
     p2.progress(0.5).await;
     p1.finish().await;
     p2.finish().await;
-    // TODO: we should have a better rule for combining labels.
+    // TODO: we should have a better rule for combining labels,
+    // or give more information to the callback.
     // This test is looking for "first nonempty nonfinished label".
     assert_eq!(
         r.drain(),


### PR DESCRIPTION
The longer name is to leave room for adding a more general operation which allows uneven or otherwise annotated splits.