### PR TITLE
Reduce overhead from async blocks.

### DIFF
--- a/src/maybe_sync.rs
+++ b/src/maybe_sync.rs
@@ -10,6 +10,8 @@ mod sync {
     pub(crate) use std::sync::Arc as MaRc;
     pub(crate) use std::sync::Mutex as StateCell;
 
+    // stub definition; the real one is only used when the feature is disabled
+    #[allow(dead_code)]
     pub(crate) trait Mutexish {}
 
     macro_rules! maybe_send_impl_future {


### PR DESCRIPTION
Using `rustc -Zprint-type-sizes`, I have examined the size of the generated future types for `finish_and_cut()` and `Yielding::yield_only()`, and removed unnecessary fields by reducing variables’ scope to not cross await points.