### PR TITLE
CI: Don't try to update if testing against 1.63.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,18 @@ jobs:
       run: cargo build --no-default-features --features="${{ matrix.features }}" --target wasm32-unknown-unknown
 
     - name: Update
+      # can't update because 1.63.0 is too old for MSRV-aware resolver
+      if: ${{ matrix.toolchain != '1.63.0' }}
       run: cargo update
 
     - name: Compile with updates
+      # can't update because 1.63.0 is too old for MSRV-aware resolver
+      if: ${{ matrix.toolchain != '1.63.0' }}
       run: cargo test --no-default-features --features="${{ matrix.features }}" --timings --no-run
 
     - name: Test with updates
+      # can't update because 1.63.0 is too old for MSRV-aware resolver
+      if: ${{ matrix.toolchain != '1.63.0' }}
       run: cargo test --no-default-features --features="${{ matrix.features }}" --timings
 
     # Save timing reports so we can download and view them


### PR DESCRIPTION
This avoids ``error: package `tokio-macros v2.5.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.63.0``.

Eventually (arguably, right now) it will make more sense to raise MSRV, but this sorts things out for now.