### PR TITLE
Switch to Rust edition 2024.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Keep this in sync with the `semver` job's matrix
-        toolchain: [stable, 1.63.0, beta, nightly]
+        toolchain: [stable, 1.85.0, beta, nightly]
         features: ['', 'sync', 'log_hiccups', 'sync,log_hiccups']
 
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "yield-progress"
 version = "0.2.0"
-edition = "2021"
-rust-version = "1.63.0"
+edition = "2024"
+rust-version = "1.85.0"
 description = "Combined progress reporting and cooperative task yielding."
 repository = "https://github.com/kpreid/yield-progress"
 license = "MIT OR Apache-2.0"

--- a/src/basic_yield.rs
+++ b/src/basic_yield.rs
@@ -33,7 +33,7 @@ use super::YieldProgress;
 ///
 /// [wake]: core::task::Waker::wake()
 /// [`tokio::task::yield_now()`]: https://docs.rs/tokio/1/tokio/task/fn.yield_now.html
-pub fn basic_yield_now() -> impl Future<Output = ()> + fmt::Debug + Send + 'static {
+pub fn basic_yield_now() -> impl Future<Output = ()> + fmt::Debug + Send {
     BasicYieldNow { state: State::New }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,7 @@ use core::future::Future;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 
-use crate::{basic_yield_now, BoxFuture, ProgressInfo, YieldInfo, YieldProgress, Yielding};
+use crate::{BoxFuture, ProgressInfo, YieldInfo, YieldProgress, Yielding, basic_yield_now};
 
 /// Builder for creating root [`YieldProgress`] instances.
 #[derive(Clone)]


### PR DESCRIPTION
This will get us faster doctest execution, precise capturing (perhaps somewhat unfortunately), and a lack of MSRV warnings for updating our dependencies.